### PR TITLE
Gradle Compilation to Implementation

### DIFF
--- a/complete/bookstore/build.gradle
+++ b/complete/bookstore/build.gradle
@@ -31,8 +31,8 @@ repositories {
 
 
 dependencies {
-	compile('org.springframework.boot:spring-boot-starter-webflux')
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation('org.springframework.boot:spring-boot-starter-webflux')
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 
 

--- a/complete/reading/build.gradle
+++ b/complete/reading/build.gradle
@@ -31,16 +31,21 @@ repositories {
 
 
 dependencies {
-	compile('org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j')
-	compile('org.springframework.boot:spring-boot-starter-webflux')
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation('org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j')
+	implementation('org.springframework.boot:spring-boot-starter-webflux')
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
+}
+
+ext {
+	set('springCloudVersion', "2020.0.3")
 }
 
 dependencyManagement {
 	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:Hoxton.SR1"
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 	}
 }
+
 
 eclipse {
 	classpath {

--- a/complete/reading/pom.xml
+++ b/complete/reading/pom.xml
@@ -35,6 +35,7 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>
@@ -42,7 +43,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>Hoxton.SR1</version>
+				<version>2020.0.3</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/initial/bookstore/build.gradle
+++ b/initial/bookstore/build.gradle
@@ -31,8 +31,8 @@ repositories {
 
 
 dependencies {
-	compile('org.springframework.boot:spring-boot-starter-webflux')
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation('org.springframework.boot:spring-boot-starter-webflux')
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 
 

--- a/initial/reading/build.gradle
+++ b/initial/reading/build.gradle
@@ -31,9 +31,9 @@ repositories {
 
 
 dependencies {
-	compile('spring-cloud-starter-circuitbreaker-reactor-resilience4j')
-	compile('org.springframework.boot:spring-boot-starter-webflux')
-	testCompile('org.springframework.boot:spring-boot-starter-test')
+	implementation('spring-cloud-starter-circuitbreaker-reactor-resilience4j')
+	implementation('org.springframework.boot:spring-boot-starter-webflux')
+	testImplementation('org.springframework.boot:spring-boot-starter-test')
 }
 
 dependencyManagement {

--- a/initial/reading/pom.xml
+++ b/initial/reading/pom.xml
@@ -42,7 +42,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>Hoxton.SR1</version>
+				<version>2020.0.3</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Fix gradle build. compilation 

1. Gradle deprecates `compile`, and instead use `implementation`


![image](https://user-images.githubusercontent.com/21094604/131933824-9c723478-d826-4e60-b2ad-4932475141c2.png)

2. add the correct version to spring-cloud according to the [table](https://spring.io/projects/spring-cloud)

