### PR TITLE
Fix missing group in circuitbreaker starter dependency

### DIFF
--- a/initial/reading/build.gradle
+++ b/initial/reading/build.gradle
@@ -31,7 +31,7 @@ repositories {
 
 
 dependencies {
-	implementation('spring-cloud-starter-circuitbreaker-reactor-resilience4j')
+	implementation('org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j')
 	implementation('org.springframework.boot:spring-boot-starter-webflux')
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 }


### PR DESCRIPTION
Fixing a syntax error in sample `build.gradle`